### PR TITLE
Use enums for Lead origem and status

### DIFF
--- a/src/main/java/br/com/clientejacrm/entity/Lead.java
+++ b/src/main/java/br/com/clientejacrm/entity/Lead.java
@@ -6,6 +6,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +31,12 @@ public class Lead {
     private String nome;
     private String email;
     private String telefone;
-    private String origem; // ex: Instagram, Indicação, Site
 
-    private String status; // NOVO, EM_CONTATO, PROPOSTA, FECHADO, PERDIDO
+    @Enumerated(EnumType.STRING)
+    private Origem origem; // ex: Instagram, Indicação, Site
+
+    @Enumerated(EnumType.STRING)
+    private Status status; // NOVO, EM_CONTATO, PROPOSTA, FECHADO, PERDIDO
 
     private LocalDateTime dataCriacao;
     private LocalDateTime proximoFollowUp;

--- a/src/main/java/br/com/clientejacrm/entity/Origem.java
+++ b/src/main/java/br/com/clientejacrm/entity/Origem.java
@@ -1,0 +1,7 @@
+package br.com.clientejacrm.entity;
+
+public enum Origem {
+    INSTAGRAM,
+    INDICACAO,
+    SITE
+}

--- a/src/main/java/br/com/clientejacrm/entity/Status.java
+++ b/src/main/java/br/com/clientejacrm/entity/Status.java
@@ -1,0 +1,9 @@
+package br.com.clientejacrm.entity;
+
+public enum Status {
+    NOVO,
+    EM_CONTATO,
+    PROPOSTA,
+    FECHADO,
+    PERDIDO
+}


### PR DESCRIPTION
## Summary
- introduce `Origem` and `Status` enums
- store lead origin and status using the new enums

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848f452063c8323b320ae3a2fb06efe