### PR TITLE
Fix JSON serialization for Lead endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- replace `quarkus-jackson` with `quarkus-rest-jackson` to enable JSON support for REST resources

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848fdf91bb883238cbfbeddbd1963b3