### PR TITLE
Add Codex devcontainer with PostgreSQL

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "clientejacrm-dev",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace/clientejacrm",
+  "runServices": ["db"],
+  "forwardPorts": [8080, 5432],
+  "postCreateCommand": "chmod +x mvnw"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/java:0-21
+    volumes:
+      - ..:/workspace/clientejacrm:cached
+    networks:
+      - dev
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: clientejacrm
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: senha123
+    ports:
+      - "5432:5432"
+    networks:
+      - dev
+networks:
+  dev:

--- a/README.md
+++ b/README.md
@@ -60,3 +60,24 @@ If you want to learn more about building native executables, please consult <htt
 Easily start your REST Web Services
 
 [Related guide section...](https://quarkus.io/guides/getting-started-reactive#reactive-jax-rs-resources)
+
+## Development container
+
+This repository contains a `.devcontainer` folder used by Codex to start the
+development environment. When the container is launched a PostgreSQL service is
+started automatically using the credentials from
+`src/main/resources/application.properties`:
+
+```
+database:     clientejacrm
+username:     postgres
+password:     senha123
+```
+
+To start the environment manually you can run:
+
+```bash
+docker compose -f .devcontainer/docker-compose.yml up -d
+```
+
+The API will be accessible on port `8080` and the database on `5432`.


### PR DESCRIPTION
## Summary
- add `.devcontainer` folder with configuration
- start a PostgreSQL service for development
- document how to use the dev container

## Testing
- `sudo service postgresql start`
- `sudo -u postgres psql -c "\l"`
- `PGPASSWORD=senha123 psql -h localhost -U postgres -d clientejacrm -c '\dt'`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849a7d4f5a883239e2b929052e3b932