### PR TITLE
fix: remove redundant rest client dependency

### DIFF
--- a/docs/whatsapp_integration.md
+++ b/docs/whatsapp_integration.md
@@ -4,7 +4,7 @@ Este guia descreve como utilizar o servidor **wppconnect-serve** para enviar men
 
 ## Configuração
 
-1. Mantenha a dependência `quarkus-rest-client-reactive` no `pom.xml`.
+1. Adicione a dependência `quarkus-rest-client-jackson` ao `pom.xml`.
 2. Defina em `application.properties` o endereço do serviço:
 
 ```properties

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- drop duplicate quarkus REST client entry from pom to avoid artifactId duplication
- document only the required quarkus-rest-client-jackson dependency for WhatsApp integration

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aceb8a48448323b7440853d7701fb4