### PR TITLE
Fix rest client dependency version mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <version>3.14.4</version>
             <artifactId>quarkus-rest-client</artifactId>
         </dependency>
 


### PR DESCRIPTION
## Summary
- align quarkus-rest-client with platform-managed version to prevent runtime NoSuchMethodError

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acf000aea083239966f871f274cdb3