### PR TITLE
Fix WhatsApp client base URL

### DIFF
--- a/docs/whatsapp_integration.md
+++ b/docs/whatsapp_integration.md
@@ -9,7 +9,7 @@ Este guia descreve como utilizar o servidor **wppconnect-serve** para enviar men
 2. Defina em `application.properties` o endereço do serviço:
 
 ```properties
-wppconnect.base-url=http://localhost:3030/
+wppconnect.base-url=http://localhost:3030
 quarkus.rest-client.wppconnect.url=${wppconnect.base-url}
 ```
 

--- a/src/main/java/br/com/clientejacrm/whatsapp/WhatsAppClient.java
+++ b/src/main/java/br/com/clientejacrm/whatsapp/WhatsAppClient.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@Path("/whatsapp/")
+@Path("/whatsapp")
 @RegisterRestClient(configKey = "wppconnect")
 public interface WhatsAppClient {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,5 +9,5 @@ quarkus.hibernate-orm.database.generation=update
 quarkus.http.root-path=/api
 
 # Configuracoes do WPPConnect
-wppconnect.base-url=http://localhost:3000/
+wppconnect.base-url=http://localhost:3000
 quarkus.rest-client.wppconnect.url=${wppconnect.base-url}


### PR DESCRIPTION
## Summary
- prevent double slashes in WhatsApp REST calls by normalizing client and base URL
- update configuration and docs

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acf0f0a9148323bc7737a210645ce1