### PR TITLE
Fix WhatsApp client endpoint path

### DIFF
--- a/docs/whatsapp_integration.md
+++ b/docs/whatsapp_integration.md
@@ -9,7 +9,7 @@ Este guia descreve como utilizar o servidor **wppconnect-serve** para enviar men
 2. Defina em `application.properties` o endereço do serviço:
 
 ```properties
-wppconnect.base-url=http://localhost:3030
+wppconnect.base-url=http://localhost:3000
 quarkus.rest-client.wppconnect.url=${wppconnect.base-url}
 ```
 

--- a/src/main/java/br/com/clientejacrm/whatsapp/WhatsAppClient.java
+++ b/src/main/java/br/com/clientejacrm/whatsapp/WhatsAppClient.java
@@ -7,12 +7,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@Path("/whatsapp")
 @RegisterRestClient(configKey = "wppconnect")
 public interface WhatsAppClient {
 
     @POST
-    @Path("send-message")
+    @Path("/send-message")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     void sendMessage(MessageRequest request);


### PR DESCRIPTION
## Summary
- remove '/whatsapp' prefix from WhatsAppClient and target /send-message
- update WhatsApp integration docs for new base URL

## Testing
- ⚠️ `./mvnw -q test` *(network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acf291c69c8323ba48c7768772c0cc