### PR TITLE
Integrate Gemini AI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,16 @@ docker compose -f .devcontainer/docker-compose.yml up -d
 ```
 
 A API estará disponível na porta `8080` e o banco de dados na `5432`.
+
+## Integração com Gemini AI
+
+Para habilitar as chamadas à inteligência artificial do Gemini, defina a
+variável de ambiente `GEMINI_API_KEY` com sua chave de API antes de
+executar a aplicação:
+
+```bash
+export GEMINI_API_KEY=SUAS_CHAVE_AQUI
+```
+
+Com a aplicação em execução, é possível gerar texto acessando o endpoint
+`/gemini?prompt=SEU_PROMPT`.

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.genai</groupId>
+            <artifactId>google-genai</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/src/main/java/br/com/clientejacrm/resource/GeminiResource.java
+++ b/src/main/java/br/com/clientejacrm/resource/GeminiResource.java
@@ -1,0 +1,25 @@
+package br.com.clientejacrm.resource;
+
+import br.com.clientejacrm.service.GeminiService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/gemini")
+public class GeminiResource {
+
+    @Inject
+    GeminiService geminiService;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String generate(@QueryParam("prompt") String prompt) {
+        if (prompt == null || prompt.isEmpty()) {
+            prompt = "Explain how AI works in a few words";
+        }
+        return geminiService.generateText(prompt);
+    }
+}

--- a/src/main/java/br/com/clientejacrm/service/GeminiService.java
+++ b/src/main/java/br/com/clientejacrm/service/GeminiService.java
@@ -1,0 +1,23 @@
+package br.com.clientejacrm.service;
+
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentResponse;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class GeminiService {
+
+    private Client client;
+
+    @PostConstruct
+    void init() {
+        client = new Client();
+    }
+
+    public String generateText(String prompt) {
+        GenerateContentResponse response =
+                client.models().generateContent("gemini-2.5-flash", prompt, null);
+        return response.text();
+    }
+}


### PR DESCRIPTION
## Summary
- add google-genai dependency
- create GeminiService to call gemini-2.5-flash model
- expose /gemini endpoint and document API key usage

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2f1d766883239ff32830aa6845b5