### PR TITLE
Aceita prompt sem nome de parâmetro

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,6 @@ export GEMINI_API_KEY=SUAS_CHAVE_AQUI
 
 Com a aplicação em execução, é possível gerar texto acessando o endpoint
 `/gemini?prompt=SEU_PROMPT`.
+
+Se preferir, também é possível omitir o nome do parâmetro e enviar somente o
+texto, por exemplo: `/gemini?Olá%20tudo%20bem%3F`.

--- a/src/main/java/br/com/clientejacrm/resource/GeminiResource.java
+++ b/src/main/java/br/com/clientejacrm/resource/GeminiResource.java
@@ -6,7 +6,12 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 @Path("/gemini")
 public class GeminiResource {
@@ -16,7 +21,13 @@ public class GeminiResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String generate(@QueryParam("prompt") String prompt) {
+    public String generate(@QueryParam("prompt") String prompt, @Context UriInfo uriInfo) {
+        if (prompt == null || prompt.isEmpty()) {
+            String rawQuery = uriInfo.getRequestUri().getRawQuery();
+            if (rawQuery != null && !rawQuery.isEmpty() && !rawQuery.contains("=")) {
+                prompt = URLDecoder.decode(rawQuery, StandardCharsets.UTF_8);
+            }
+        }
         if (prompt == null || prompt.isEmpty()) {
             prompt = "Explain how AI works in a few words";
         }


### PR DESCRIPTION
## Summary
- Permite que o endpoint `/gemini` use o texto bruto da query quando o parâmetro `prompt` não é informado
- Documenta a possibilidade de enviar o texto diretamente na query string

## Testing
- `mvn -q test` *(falha: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad350cc9588323b1d315bb1711b57e