### PR TITLE
Add OpenRouter API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,19 @@ Com a aplicação em execução, é possível gerar texto acessando o endpoint
 
 Se preferir, também é possível omitir o nome do parâmetro e enviar somente o
 texto, por exemplo: `/gemini?Olá%20tudo%20bem%3F`.
+
+## Integração com OpenRouter
+
+Para habilitar as chamadas à API do OpenRouter, defina a
+variável de ambiente `OPENROUTER_API_KEY` com sua chave antes de
+executar a aplicação:
+
+```bash
+export OPENROUTER_API_KEY=SUAS_CHAVE_AQUI
+```
+
+Com a aplicação em execução, é possível gerar texto acessando o endpoint
+`/openrouter?prompt=SEU_PROMPT`.
+
+Assim como no Gemini, também é possível omitir o nome do parâmetro e enviar
+somente o texto, por exemplo: `/openrouter?Olá%20tudo%20bem%3F`.

--- a/src/main/java/br/com/clientejacrm/resource/OpenRouterResource.java
+++ b/src/main/java/br/com/clientejacrm/resource/OpenRouterResource.java
@@ -1,0 +1,36 @@
+package br.com.clientejacrm.resource;
+
+import br.com.clientejacrm.service.OpenRouterService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Path("/openrouter")
+public class OpenRouterResource {
+
+    @Inject
+    OpenRouterService openRouterService;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String generate(@QueryParam("prompt") String prompt, @Context UriInfo uriInfo) {
+        if (prompt == null || prompt.isEmpty()) {
+            String rawQuery = uriInfo.getRequestUri().getRawQuery();
+            if (rawQuery != null && !rawQuery.isEmpty() && !rawQuery.contains("=")) {
+                prompt = URLDecoder.decode(rawQuery, StandardCharsets.UTF_8);
+            }
+        }
+        if (prompt == null || prompt.isEmpty()) {
+            prompt = "Explain how AI works in a few words";
+        }
+        return openRouterService.generateText(prompt);
+    }
+}

--- a/src/main/java/br/com/clientejacrm/service/OpenRouterService.java
+++ b/src/main/java/br/com/clientejacrm/service/OpenRouterService.java
@@ -1,0 +1,60 @@
+package br.com.clientejacrm.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class OpenRouterService {
+
+    private HttpClient httpClient;
+    private ObjectMapper objectMapper;
+
+    @PostConstruct
+    void init() {
+        httpClient = HttpClient.newHttpClient();
+        objectMapper = new ObjectMapper();
+    }
+
+    public String generateText(String prompt) {
+        try {
+            String apiKey = System.getenv("OPENROUTER_API_KEY");
+            if (apiKey == null || apiKey.isBlank()) {
+                throw new IllegalStateException("OPENROUTER_API_KEY environment variable not set");
+            }
+
+            Map<String, Object> payload = Map.of(
+                    "model", "openai/gpt-3.5-turbo",
+                    "messages", List.of(Map.of(
+                            "role", "user",
+                            "content", prompt
+                    ))
+            );
+
+            String body = objectMapper.writeValueAsString(payload);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://openrouter.ai/api/v1/chat/completions"))
+                    .header("Authorization", "Bearer " + apiKey)
+                    .header("Content-Type", "application/json")
+                    .header("HTTP-Referer", "https://clientejacrm")
+                    .header("X-Title", "ClienteJACRM")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            JsonNode json = objectMapper.readTree(response.body());
+            return json.path("choices").get(0).path("message").path("content").asText();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to call OpenRouter API", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document setup for OpenRouter API
- add service and REST endpoint to call OpenRouter's chat completions

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3af65958832380d27e3cf12c3a11