### PR TITLE
Encode user password to Base64

### DIFF
--- a/src/main/java/br/com/clientejacrm/entity/orm/Usuario.java
+++ b/src/main/java/br/com/clientejacrm/entity/orm/Usuario.java
@@ -2,6 +2,7 @@ package br.com.clientejacrm.entity.orm;
 
 import br.com.clientejacrm.entity.enums.StatusUsuario;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +20,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.Instant;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 @Data
 @Builder
@@ -36,6 +40,10 @@ public class Usuario {
 
     @Column(name = "email",  nullable = false)
     private String email;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Transient
+    private String senha;
 
     @JsonIgnore
     @Column(name = "senha_hash", nullable = false, length = 255)
@@ -59,6 +67,12 @@ public class Usuario {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
-
+    public void setSenha(String senha) {
+        this.senha = senha;
+        if (senha != null) {
+            this.senhaHash = Base64.getEncoder().encodeToString(
+                    senha.getBytes(StandardCharsets.UTF_8));
+        }
+    }
 
 }

--- a/src/main/java/br/com/clientejacrm/service/UsuarioService.java
+++ b/src/main/java/br/com/clientejacrm/service/UsuarioService.java
@@ -44,8 +44,9 @@ public class UsuarioService {
         }
         usuario.setNome(updated.getNome());
         usuario.setEmail(updated.getEmail());
-        usuario.setSenhaHash(updated.getSenhaHash());
-
+        if (updated.getSenha() != null) {
+            usuario.setSenha(updated.getSenha());
+        }
         return usuario;
     }
 


### PR DESCRIPTION
## Summary
- accept plain `senha` for `Usuario` and automatically encode it to Base64 before persisting
- update service to set encoded password when updating users

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afc88fb16483238012b914e95eb0c6