### PR TITLE
Add user filter to lead lookup by phone

### DIFF
--- a/src/main/java/br/com/clientejacrm/repository/LeadRepository.java
+++ b/src/main/java/br/com/clientejacrm/repository/LeadRepository.java
@@ -1,13 +1,14 @@
 package br.com.clientejacrm.repository;
 
 import br.com.clientejacrm.entity.orm.Lead;
+import br.com.clientejacrm.entity.orm.Usuario;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class LeadRepository implements PanacheRepository<Lead> {
 
-    public Lead findByTelefone(String telefone) {
-        return find("telefone", telefone).firstResult();
+    public Lead findByTelefone(String telefone, Usuario usuario) {
+        return find("telefone = ?1 and usuario = ?2", telefone, usuario).firstResult();
     }
 }

--- a/src/main/java/br/com/clientejacrm/service/LeadService.java
+++ b/src/main/java/br/com/clientejacrm/service/LeadService.java
@@ -43,11 +43,11 @@ public class LeadService {
 
     @Transactional
     public Lead create(Lead lead) {
-        if(leadRepository.findByTelefone(lead.getTelefone()) != null) {
+        Usuario usuario = usuarioService.getUsuarioLogado();
+        if(leadRepository.findByTelefone(lead.getTelefone(), usuario) != null) {
             throw new IllegalArgumentException("Telefone já cadastrado");
         }
 
-      Usuario usuario = usuarioService.getUsuarioLogado();
         lead.setDataCriacao(LocalDateTime.now());
         lead.setProximoFollowUp(LocalDateTime.now());
         lead.setUsuario(usuario);


### PR DESCRIPTION
## Summary
- filter lead searches by phone and user
- ensure lead creation only checks phone numbers within the logged in user's scope

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b13b1a39f88323a9450973a5703376