### PR TITLE
feat: encapsulate request errors

### DIFF
--- a/src/main/java/br/com/clientejacrm/exception/ErrorResponse.java
+++ b/src/main/java/br/com/clientejacrm/exception/ErrorResponse.java
@@ -1,0 +1,10 @@
+package br.com.clientejacrm.exception;
+
+public class ErrorResponse {
+
+    public String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/br/com/clientejacrm/exception/GlobalExceptionMapper.java
+++ b/src/main/java/br/com/clientejacrm/exception/GlobalExceptionMapper.java
@@ -1,0 +1,22 @@
+package br.com.clientejacrm.exception;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.NotFoundException;
+
+@Provider
+public class GlobalExceptionMapper implements ExceptionMapper<Throwable> {
+
+    @Override
+    public Response toResponse(Throwable exception) {
+        int status = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+        if (exception instanceof NotFoundException) {
+            status = Response.Status.NOT_FOUND.getStatusCode();
+        } else if (exception instanceof IllegalArgumentException) {
+            status = Response.Status.BAD_REQUEST.getStatusCode();
+        }
+        ErrorResponse error = new ErrorResponse(exception.getMessage());
+        return Response.status(status).entity(error).build();
+    }
+}


### PR DESCRIPTION
## Summary
- add `ErrorResponse` and `GlobalExceptionMapper` to provide compact error payloads

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b13ccda73483239ce0b5d9ef19e1cc